### PR TITLE
Close handle after parsing the tags

### DIFF
--- a/dist/id3.js
+++ b/dist/id3.js
@@ -964,6 +964,7 @@
 			}
 			ID3Tag.parse(handle, function(err, tags) {
 				cb(err, tags);
+				handle.close()
 			});
 		});
 	};


### PR DESCRIPTION
Right now, in `Reader.OPEN_LOCAL` mode, the file descriptor is not closed after the tags are read and when you are looking at 20,000 MP3s like I am, file descriptors definitely need to be closed.
