### PR TITLE
Wrapped getUnit8() in a try...catch

### DIFF
--- a/dist/id3.js
+++ b/dist/id3.js
@@ -693,9 +693,13 @@
 						}
 						i++;
 					} else {
-						if(dv.getUint8(i) === 0x00) {
-							variableStart = i + 1;
-							break;
+						try {
+							if(dv.getUint8(i) === 0x00) {
+								variableStart = i + 1;
+								break;
+							}
+						} catch(e) {
+							break;	
 						}
 					}
 				}


### PR DESCRIPTION
Wrapping this `if` clause in a `try...catch` seems to alleviate the issue found in https://github.com/43081j/id3/issues/10 and possibly https://github.com/43081j/id3/issues/9

There seems to be no real negative impact in simply ignoring any exceptions generated by the tried code, the resulting `tags` seems to be completely fine, though a more graceful method of handling the exception should probably be implemented.
