### PR TITLE
Use `encodeURIComponent` instead of `escape`.

### DIFF
--- a/lib/dataview-extra.js
+++ b/lib/dataview-extra.js
@@ -23,7 +23,7 @@ DataView.prototype.getString = function(length, offset, raw) {
 		if(raw) {
 			return str;
 		}
-		return decodeURIComponent(escape(str));
+		return decodeURIComponent(encodeURIComponent(str));
 	}
 };
 
@@ -69,7 +69,7 @@ DataView.prototype.getStringUtf16 = function(length, offset, bom) {
 	if(useBuffer) {
 		return str.toString();
 	} else {
-		return decodeURIComponent(escape(str));
+		return decodeURIComponent(encodeURIComponent(str));
 	}
 };
 


### PR DESCRIPTION
Fixed #15 for me (`Uncaught URIError: URI malformed`)

`escape` is bad practice. See http://stackoverflow.com/a/3608791/1207223