### PR TITLE
Changes to prevent crashing in certain edge cases (within mp3's in my library).

### DIFF
--- a/dist/id3.js
+++ b/dist/id3.js
@@ -227,14 +227,15 @@
 		if(length < 0) {
 			length += this.byteLength;
 		}
-		if(bom) {
-			var bomInt = this.getUint16(offset);
-			if(bomInt === 0xFFFE) {
-				littleEndian = true;
-			}
-			offset += 2;
-			length -= 2;
-		}
+		// The following is not correctly implemented currently.  It has been commented out to prevent crashing.
+		// if(bom) {
+		// 	var bomInt = this.getUint16(offset);
+		// 	if(bomInt === 0xFFFE) {
+		// 		littleEndian = true;
+		// 	}
+		// 	offset += 2;
+		// 	length -= 2;
+		// }
 		for(var i = offset; i < (offset + length); i += 2) {
 			var ch = this.getUint16(i, littleEndian);
 			if((ch >= 0 && ch <= 0xD7FF) || (ch >= 0xE000 && ch <= 0xFFFF)) {
@@ -685,7 +686,7 @@
 				/*
 				 * Skip the comment description and retrieve only the comment its self
 				 */
-				for(var i = variableStart;; i++) {
+				for(var i = variableStart; i<buffer.byteLength; i++) {
 					if(encoding === 1 || encoding === 2) {
 						if(dv.getUint16(i) === 0x0000) {
 							variableStart = i + 2;
@@ -925,6 +926,11 @@
 							frameBit,
 							isFrame = true;
 						for(var i = 0; i < 3; i++) {
+							if(position + i >= buffer.byteLength){
+								isFrame = false;
+								break;
+							}
+
 							frameBit = dv.getUint8(position + i);
 							if((frameBit < 0x41 || frameBit > 0x5A) && (frameBit < 0x30 || frameBit > 0x39)) {
 								isFrame = false;

--- a/lib/dataview-extra.js
+++ b/lib/dataview-extra.js
@@ -40,14 +40,15 @@ DataView.prototype.getStringUtf16 = function(length, offset, bom) {
 	if(length < 0) {
 		length += this.byteLength;
 	}
-	if(bom) {
-		var bomInt = this.getUint16(offset);
-		if(bomInt === 0xFFFE) {
-			littleEndian = true;
-		}
-		offset += 2;
-		length -= 2;
-	}
+	// The following is not correctly implemented currently.  It has been commented out to prevent crashing.
+	// if(bom) {
+	// 	var bomInt = this.getUint16(offset);
+	// 	if(bomInt === 0xFFFE) {
+	// 		littleEndian = true;
+	// 	}
+	// 	offset += 2;
+	// 	length -= 2;
+	// }
 	for(var i = offset; i < (offset + length); i += 2) {
 		var ch = this.getUint16(i, littleEndian);
 		if((ch >= 0 && ch <= 0xD7FF) || (ch >= 0xE000 && ch <= 0xFFFF)) {

--- a/lib/id3frame.js
+++ b/lib/id3frame.js
@@ -200,7 +200,7 @@ ID3Frame.parse = function(buffer, major, minor) {
 		/*
 		 * Skip the comment description and retrieve only the comment its self
 		 */
-		for(var i = variableStart;; i++) {
+		for(var i = variableStart; i<buffer.byteLength; i++) {
 			if(encoding === 1 || encoding === 2) {
 				if(dv.getUint16(i) === 0x0000) {
 					variableStart = i + 2;

--- a/lib/id3tag.js
+++ b/lib/id3tag.js
@@ -120,6 +120,11 @@ ID3Tag.parse = function(handle, callback) {
 					frameBit,
 					isFrame = true;
 				for(var i = 0; i < 3; i++) {
+					if(position + i >= buffer.byteLength){
+						isFrame = false;
+						break;
+					}
+
 					frameBit = dv.getUint8(position + i);
 					if((frameBit < 0x41 || frameBit > 0x5A) && (frameBit < 0x30 || frameBit > 0x39)) {
 						isFrame = false;


### PR DESCRIPTION
I added a few checks/tweaks to fix cases that were causing crashes due to "Index out of range" errors on mp3's in my library.
