### PR TITLE
Remove old entrypoint & trim v1 tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You may parse ID3 tags of a remote MP3 by URL:
 
 ```html
 <script type="module">
-import * as id3 from '//unpkg.com/id3js@^2/id3.js';
+import * as id3 from '//unpkg.com/id3js@^2/lib/id3.js';
 
 id3.fromUrl('/audio/track.mp3').then((tags) => {
   // tags now contains v1, v2 and merged tags
@@ -41,7 +41,7 @@ downloaded.
 You may parse ID3 tags of a local file in Node:
 
 ```ts
-import * as id3 from './node_modules/id3js/id3.js';
+import * as id3 from 'id3js';
 
 id3.fromPath('./test.mp3').then((tags) => {
   // tags now contains v1, v2 and merged tags
@@ -59,7 +59,7 @@ You may parse ID3 tags of a file input:
 <input type="file">
 
 <script type="module">
-import * as id3 from '//unpkg.com/id3js@^2/id3.js';
+import * as id3 from '//unpkg.com/id3js@^2/lib/id3.js';
 
 document
   .querySelector('input[type="file"]')

--- a/id3.js
+++ b/id3.js
@@ -1,1 +1,0 @@
-export * from './lib/id3.js';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "author": "43081j",
   "description": "A modern ID3 parser written completely in JavaScript, making use of typed arrays and the HTML5 File API",
-  "main": "./id3.js",
+  "main": "./lib/id3.js",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/id3Tag.ts
+++ b/src/id3Tag.ts
@@ -46,10 +46,10 @@ export async function parse(handle: Reader): Promise<ID3Tag | null> {
   ) {
     tag = {
       kind: 'v1',
-      title: getString(v1Header, 30, 3) || null,
-      album: getString(v1Header, 30, 63) || null,
-      artist: getString(v1Header, 30, 33) || null,
-      year: getString(v1Header, 4, 93) || null,
+      title: getString(v1Header, 30, 3).trim() || null,
+      album: getString(v1Header, 30, 63).trim() || null,
+      artist: getString(v1Header, 30, 33).trim() || null,
+      year: getString(v1Header, 4, 93).trim() || null,
       genre: null,
       comment: null,
       track: null


### PR DESCRIPTION
This just re-applies a `trim` to v1 tags as they often have 0x22 (a space) as opposed to 0x00 (null byte).

It also removes the id3.js entrypoint and requires `lib/id3.js`