### PR TITLE
Improve handling of UTF-16 strings in Node.js and prevent out of bound error when attempting to parse incomplete frames at the end

### DIFF
--- a/src/id3Tag.ts
+++ b/src/id3Tag.ts
@@ -125,7 +125,11 @@ export async function parse(handle: Reader): Promise<ID3Tag | null> {
       const v2Tag = new DataView(v2TagBuf);
       let position = 0;
 
-      while (position < v2TagBuf.byteLength) {
+      const frameHeaderSize =  version[0] < 3 ? 6 : 10;
+      /*
+       * Skip incomplete frames at the end
+       */
+      while (position + frameHeaderSize < v2TagBuf.byteLength) {
         let slice;
         let isFrame = true;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -105,17 +105,8 @@ export function getStringUtf16(
   }
 
   if (useBuffer) {
-    const buf = Buffer.alloc(str.length * 2);
-    for (let i = 0; i < str.length; i++) {
-      const chr = str[i];
-
-      if (littleEndian) {
-        buf.writeUInt16LE(chr, i * 2);
-      } else {
-        buf.writeUInt16BE(chr, i * 2);
-      }
-    }
-    return buf.toString();
+    const buf = Buffer.from(new Uint16Array(str).buffer);
+    return buf.toString('utf16le');
   }
 
   return String.fromCharCode.apply(


### PR DESCRIPTION
- Some malformed ID3V2 tags like the ones created by LAME 3.96.1 have padding bytes after all the frames. This code patches the loop condition to end the loop early when there is not enough bytes left in the tag for a full frame header (6 for v2.2, 10 for v2.3) to prevent a crash when reading those tags
- the previous UTF-16 reading code, in the Buffer/nodejs case, would create a character for each byte in the input rather than doing the proper decoding. This is a temporary solution until a more robust solution using [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder), which supports both nodejs and browser, is implemented